### PR TITLE
CLI and dtype handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,13 @@ def get_param(key, local=False):
   config = Config(local=local)
   return config[key]
 
->>> set_param('persist', True)
->>> get_param('persist')
+>>> set_param('persist', True) # Global
+>>> get_param('persist') # Global
 True
 >>> set_param('local', True, local=True)
 >>> get_param('local')
 Null
->>> get_param('persist', local=True)
+>>> get_param('persist', local=True) # Copies global instance
 True
 ```
 

--- a/mlky/__init__.py
+++ b/mlky/__init__.py
@@ -1,6 +1,6 @@
 """
 """
-__version__ = '2024.01.1'
+__version__ = '2024.03.1'
 
 # Instantiate before the CLI
 from mlky.configs     import *

--- a/mlky/configs/__init__.py
+++ b/mlky/configs/__init__.py
@@ -1,6 +1,9 @@
 """
 Order of operations matter due to dependencies
 """
+# Regex string for matching to mlky magics
+magic_regex = r"\${([\.\$\!].*?)}"
+
 # Independent
 from .null import (
     Null,

--- a/mlky/configs/builtins.py
+++ b/mlky/configs/builtins.py
@@ -339,5 +339,5 @@ def check_dtype(value, dtype):
         check = isinstance(value, dtype)
 
     if check is False:
-        return f'Wrong type: Expected <{dtype!r}> Got {type(value)}'
+        return f'Wrong type: Expected {dtype!r} Got {type(value)}'
     return check

--- a/mlky/configs/builtins.py
+++ b/mlky/configs/builtins.py
@@ -6,6 +6,8 @@ import os
 import re
 import uuid
 
+from types import FunctionType
+
 from . import (
     funcs,
     Null,
@@ -293,26 +295,8 @@ def mutually_exclusive(items):
     return True
 
 
-## Builtin provided type functions
-# More types can be added by importing this dict and appending to it
-# Or by registering a function with the same name as the type
-Types = {
-    Null     : lambda value: True,
-    'Null'   : lambda value: True,
-    None     : lambda value: True,
-    'None'   : lambda value: True,
-    'any'    : lambda value: True,
-    'bool'   : lambda value: isinstance(value, bool   ),
-    'bytes'  : lambda value: isinstance(value, bytes  ),
-    'complex': lambda value: isinstance(value, complex),
-    'dict'   : lambda value: isinstance(value, dict   ),
-    'float'  : lambda value: isinstance(value, float  ),
-    'int'    : lambda value: isinstance(value, int    ),
-    'list'   : lambda value: isinstance(value, list   ),
-    'set'    : lambda value: isinstance(value, set    ),
-    'str'    : lambda value: isinstance(value, str    ),
-    'tuple'  : lambda value: isinstance(value, tuple  )
-}
+# dtypes assigned to these values always pass checks
+Typeless = (Null, 'Null', None, 'None', 'any')
 
 @register()
 def check_dtype(value, dtype):
@@ -335,20 +319,25 @@ def check_dtype(value, dtype):
         Returns True if this value is the expected type. If it is not, returns
         either a string or list of strings describing the error.
     """
+    if dtype in Typeless:
+        return True
+
     if isinstance(dtype, list):
         if True not in [check_type(value, t) for t in dtype]:
             return f'Value type <{dtype!r}> is not one of {dtype}'
         return True
 
-    # Try a builtin then fallback to custom registered
-    func = Types.get(dtype, funcs.Funcs.get(dtype))
-    if func is None:
+    # Use a custom function to check the type
+    if isinstance(dtype, FunctionType):
+        check = dtype(value)
+
+    # If not a function, this must be a python-registered type
+    elif not isinstance(dtype, type):
         return f'Unknown type: {dtype!r}'
 
-    ret = func(value)
-    if ret is True:
-        return True
-    if isinstance(ret, (str, list)):
-        return ret
     else:
+        check = isinstance(value, dtype)
+
+    if check is False:
         return f'Wrong type: Expected <{dtype!r}> Got {type(value)}'
+    return check

--- a/mlky/configs/magics.py
+++ b/mlky/configs/magics.py
@@ -16,7 +16,7 @@ Logger = logging.getLogger(__file__)
 
 
 @register(name='config.replace')
-def replace(value, instance=None):
+def replace(value, instance=None, dtype=None):
     """
     Replaces format signals in strings with values from the config relative to
     its inheritance structure.
@@ -28,11 +28,13 @@ def replace(value, instance=None):
         corrosponding config value. See notes the regex for accuracy.
     instance: Sect, defaults=None
         Instance to use for value lookups. Defaults to the global instance
+    dtype: any, defaults=None
+        Data type to attempt casting the replacement value to
 
     Returns
     -------
-    string: str
-        Same string but with the values replaced.
+    value: any
+        Replaced value
 
     Notes
     -----
@@ -111,6 +113,18 @@ def replace(value, instance=None):
                 Logger.warning(f'Replacement matched to string but no valid starter token provided: {match!r}')
 
             value = value.replace('${'+ match +'}', str(data))
+
+    if dtype:
+        if isinstance(dtype, list):
+            Logger.debug(f'Cannot cast replacement value {value!r} as the dtype is a list and cannot be assumed: {dtype=}')
+        elif dtype in (list, tuple):
+            # Logger.debug(f'List dtype casting is not supported')
+            pass
+        else:
+            try:
+                value = dtype(value)
+            except:
+                Logger.error(f'Failed to cast replacement value {value!r} to {dtype=}')
 
     return value
 

--- a/mlky/configs/magics.py
+++ b/mlky/configs/magics.py
@@ -7,6 +7,7 @@ import re
 from . import (
     Config,
     funcs,
+    magic_regex,
     Null,
     register
 )
@@ -79,7 +80,7 @@ def replace(value, instance=None, dtype=None):
         if value == '\\':
             return Null
 
-        matches = re.findall(r"\${([\.\$\!].*?)}", value)
+        matches = re.findall(magic_regex, value)
 
         for match in matches:
             # Config lookup case

--- a/mlky/configs/sect.py
+++ b/mlky/configs/sect.py
@@ -59,7 +59,8 @@ class Sect:
         # TODO: (Doc this better) Not converting list types will prevent the ability to patch them, values for these keys will simply be replaced on patch
         convertListTypes = True,
         convertItems     = True,
-        VarsReplaceInit  = True
+        VarsReplaceInit  = True,
+        Var              = Var # Passthrough to access Var options via this dict
     )
 
     # Class defaults, change these manually via Sect.__dict__[key] = ...

--- a/mlky/configs/tests/test_magics.py
+++ b/mlky/configs/tests/test_magics.py
@@ -1,0 +1,43 @@
+"""
+Tests mlky magics
+"""
+import re
+
+import pytest
+
+from mlky.configs import magic_regex
+
+@pytest.mark.parametrize("string,expected", [
+    ("${.}", True),
+    ("${.n}", True),
+    ("${.\}", True),
+    ("${.0}", True),
+    ("${..}", True),
+    ("${$}", True),
+    ("${$n}", True),
+    ("${$\}", True),
+    ("${$0}", True),
+    ("${$.}", True),
+    ("${!}", True),
+    ("${!n}", True),
+    ("${!\}", True),
+    ("${!0}", True),
+    ("${!.}", True),
+    ("", False),
+    ("$", False),
+    ("${", False),
+    ("${}", False),
+    ("${?}", False),
+    ("${@}", False),
+    ("${n}", False),
+    ("${\}", False),
+    ("${0}", False),
+    (".n", False),
+    ("$n", False),
+    ("!n", False),
+])
+def test_magic_regex(string, expected):
+    """
+    Ensures the regex is working in expected ways
+    """
+    assert bool(re.match(magic_regex, string)) == expected

--- a/mlky/configs/tests/test_var.py
+++ b/mlky/configs/tests/test_var.py
@@ -14,14 +14,15 @@ from mlky import (
 @pytest.mark.parametrize("name,key,value,dtype,checks,errors", [
     ('.1', 'one'  , 1, 'None', [{'oneof': [0, 1, 2]}], {}),
     ('.2', 'two'  , 2, 'any' , [{'oneof': [0, 2, 4]}], {}),
-    ('.3', 'three', 3, 'int' , [{'oneof': [0, 2, 4]}], {'oneof': 'Invalid option: 3, should be one of: (0, 2, 4)'}),
-    ('.4', 'four' , 4, 'str' , [{'oneof': [0, 4, 8]}], {'type': "Wrong type: Expected <'str'> Got <class 'int'>"})
+    ('.3', 'three', 3, int   , [{'oneof': [0, 2, 4]}], {'oneof': 'Invalid option: 3, should be one of: (0, 2, 4)'}),
+    ('.4', 'four' , 4, str   , [{'oneof': [0, 4, 8]}], {'type': "Wrong type: Expected <class 'str'> Got <class 'int'>"})
 ])
 def test_Var(name, key, value, dtype, checks, errors):
     """
     Tests initialization and briefly validation
     """
     v = Var(name=name, key=key, value=value, dtype=dtype, checks=checks)
+
     assert str(v)   == f'<Var({key}={value})>', f'Var str() broken, expected "<Var({key}={value})>" got {str(v)}'
     assert v.name   == name,   f'Bad attribute "name", expected {name} got {v.name}'
     assert v.key    == key,    f'Bad attribute "key", expected {key} got {v.key}'

--- a/mlky/configs/var.py
+++ b/mlky/configs/var.py
@@ -3,11 +3,13 @@ Var objects are containers to hold values of a mlky Sect
 """
 import copy
 import logging
+import re
 import yaml
 
 from . import (
     ErrorsDict,
     funcs,
+    magic_regex,
     Null
 )
 
@@ -38,6 +40,9 @@ class Var:
 
     # .reset() will replace magic strings "${...}", this will disable that
     _disable_reset_magics = False
+
+    # Will only call replace on magic strings, not any value
+    _replace_only_if_magic = True
 
     # Assists getValue() to retrieve a temporary value without setting it as .value
     _tmp_value = Null
@@ -375,6 +380,11 @@ class Var:
 
         Work in progress
         """
+        # Call replacement on string types only if option is set
+        if self._replace_only_if_magic:
+            if not isinstance(value, str) or not re.match(magic_regex, value):
+                return
+
         # Find the root parent
         parent = self.parent
         while parent._prnt:


### PR DESCRIPTION
# Changes
- Fixes CLI `mlky generate` function to work in the new architecture
- Reworked dtypes of Vars to enable casting magic replacements from str to their expected type
  - This enables using magics referencing other config variables to be the correct type
- Added option Var to disable `Var.reset()` from calling `replace()` on values that are magics. This allows `mlky generate` to toggle magic replacements when generating from a definitions file