### PR TITLE
Fix Slashes to Null

### DIFF
--- a/mlky/__init__.py
+++ b/mlky/__init__.py
@@ -1,6 +1,6 @@
 """
 """
-__version__ = '2024.03.2'
+__version__ = '2024.03.3'
 
 # Instantiate before the CLI
 from mlky.configs     import *

--- a/mlky/configs/tests/test_config.py
+++ b/mlky/configs/tests/test_config.py
@@ -3,7 +3,10 @@ Tests the mlky Config class
 """
 import pytest
 
-from mlky import Config
+from mlky import (
+    Config,
+    Null
+)
 
 
 def test_init():
@@ -92,3 +95,50 @@ def test_replace():
     C = Config({'a': '${.b}', 'b': 2})
     assert C.a == '2'
     assert C.b == 2
+
+
+YAML = """\
+a: \\
+b: //
+d: -1
+e: -1
+"""
+
+DEFS = """\
+.a:
+    dtype: str
+.b:
+    dtype: str
+.c:
+    dtype: str
+    default: C
+.d:
+    dtype: int
+.e:
+    dtype: float
+.f:
+    dtype: str
+"""
+
+def test_replace():
+    """
+    Test function to validate the behavior of the 'replace' function.
+
+    This function creates a 'Config' instance using the provided YAML data and definitions.
+    It then asserts various attributes of the 'Config' instance to ensure proper replacement.
+
+    Asserts
+    -------
+    - 'a' should be Null
+    - 'b' should be '//'
+    - 'c' should be 'C' (default value)
+    - 'd' should be -1
+    - 'e' should be -1. (float type)
+    """
+    Config(data=YAML, defs=DEFS)
+
+    assert Config.a is Null
+    assert Config.b == '//'
+    assert Config.c == 'C'
+    assert Config.d == -1
+    assert Config.e == -1.

--- a/mlky/configs/var.py
+++ b/mlky/configs/var.py
@@ -44,6 +44,9 @@ class Var:
     # Will only call replace on magic strings, not any value
     _replace_only_if_magic = True
 
+    # Replace backslashes "\" with Null
+    _replace_slash_null = True
+
     # Assists getValue() to retrieve a temporary value without setting it as .value
     _tmp_value = Null
 
@@ -380,8 +383,12 @@ class Var:
 
         Work in progress
         """
+        # Allow "\" values to be passed through to the replace function which will be replaced with Null
+        if self._replace_slash_null and value == '\\':
+            pass
+
         # Call replacement on string types only if option is set
-        if self._replace_only_if_magic:
+        elif self._replace_only_if_magic:
             if not isinstance(value, str) or not re.match(magic_regex, value):
                 return
 


### PR DESCRIPTION
Fixes Var objects not replacing backslashes with Null objects from the recent dtype changes. Makes this optional, on by default. Added some test cases to hopefully catch this in the future. 