### PR TITLE
Fix Var replacing slashes with Null

### DIFF
--- a/mlky/__init__.py
+++ b/mlky/__init__.py
@@ -1,6 +1,6 @@
 """
 """
-__version__ = '2024.03.3'
+__version__ = '2024.03.4'
 
 # Instantiate before the CLI
 from mlky.configs     import *

--- a/mlky/configs/var.py
+++ b/mlky/configs/var.py
@@ -384,7 +384,7 @@ class Var:
         Work in progress
         """
         # Allow "\" values to be passed through to the replace function which will be replaced with Null
-        if self._replace_slash_null and value == '\\':
+        if self._replace_slash_null and isinstance(value, str) and value == '\\':
             pass
 
         # Call replacement on string types only if option is set


### PR DESCRIPTION
Fixes `Var._replace_slash_null` to check if the value is a str type before `== '\'` because without will cause pandas DataFrames to raise an exception.