### PR TITLE
Fix Var not replacing magics later in the string

### DIFF
--- a/mlky/__init__.py
+++ b/mlky/__init__.py
@@ -1,6 +1,6 @@
 """
 """
-__version__ = '2024.03.4'
+__version__ = '2024.03.5'
 
 # Instantiate before the CLI
 from mlky.configs     import *

--- a/mlky/configs/tests/test_magics.py
+++ b/mlky/configs/tests/test_magics.py
@@ -35,9 +35,25 @@ from mlky.configs import magic_regex
     (".n", False),
     ("$n", False),
     ("!n", False),
+    # Test strings that have magics but don't start with it
+    (". ${.}", True),
+    (". ${.n}", True),
+    (". ${.\}", True),
+    (". ${.0}", True),
+    (". ${..}", True),
+    (". ${$}", True),
+    (". ${$n}", True),
+    (". ${$\}", True),
+    (". ${$0}", True),
+    (". ${$.}", True),
+    (". ${!}", True),
+    (". ${!n}", True),
+    (". ${!\}", True),
+    (". ${!0}", True),
+    (". ${!.}", True),
 ])
 def test_magic_regex(string, expected):
     """
     Ensures the regex is working in expected ways
     """
-    assert bool(re.match(magic_regex, string)) == expected
+    assert bool(re.findall(magic_regex, string)) == expected

--- a/mlky/configs/var.py
+++ b/mlky/configs/var.py
@@ -383,14 +383,19 @@ class Var:
 
         Work in progress
         """
-        # Allow "\" values to be passed through to the replace function which will be replaced with Null
-        if self._replace_slash_null and isinstance(value, str) and value == '\\':
-            pass
+        if isinstance(value, str):
+            # Allow "\" values to be passed through to the replace function which will be replaced with Null
+            if self._replace_slash_null and value == '\\':
+                pass
+
+            # Ensure a string has a magic
+            elif self._replace_only_if_magic:
+                if not re.findall(magic_regex, value):
+                    return
 
         # Call replacement on string types only if option is set
         elif self._replace_only_if_magic:
-            if not isinstance(value, str) or not re.match(magic_regex, value):
-                return
+            return
 
         # Find the root parent
         parent = self.parent


### PR DESCRIPTION
The recently new `Var._replace_only_if_magic` option was causing strings that contained a magic later in the string to fail due to `re.match`. Fixed via `re.findall`