### PR TITLE
Subtypes

### DIFF
--- a/mlky/__init__.py
+++ b/mlky/__init__.py
@@ -1,6 +1,6 @@
 """
 """
-__version__ = '2024.03.5'
+__version__ = '2024.04.1'
 
 # Instantiate before the CLI
 from mlky.configs     import *

--- a/mlky/configs/builtins.py
+++ b/mlky/configs/builtins.py
@@ -323,6 +323,39 @@ def mutually_exclusive(items):
     return True
 
 
+@register
+def if_one_then_all(items):
+    """
+    If one item is defined then all must be defined
+
+    Parameters
+    ----------
+    items: list of Var
+        Var objects to validate on
+
+    Returns
+    -------
+    True | str
+        Returns True if one item is valid, otherwise returns an error string
+
+    Notes
+    -----
+    This is a Sect check function, not be used for Vars
+    """
+    defined   = []
+    undefined = []
+    for item in items:
+        name = item._f.name
+        if item._f.value is not Null:
+            defined.append(name)
+        else:
+            undefined.append(name)
+
+    if defined and undefined:
+        return f'If one is defined, all must be defined: defined={defined}, undefined={undefined}'
+    return True
+
+
 # dtypes assigned to these values always pass checks
 Typeless = (Null, 'Null', None, 'None', 'any')
 

--- a/mlky/configs/builtins.py
+++ b/mlky/configs/builtins.py
@@ -29,7 +29,7 @@ def get_env(key, other=''):
 
     Returns
     -------
-    str, any
+    str | any
         If the key exists the return will be a str, otherwise return the `other`
         parameter
     """
@@ -100,7 +100,7 @@ def oneof(var, *opts, options=[], regex=False):
 
     Returns
     -------
-    True, str
+    True | str
         Returns True if `value` is oneof `options`, otherwise return an error
         message as a string
     """
@@ -152,7 +152,7 @@ def isdir(var):
 
     Returns
     -------
-    bool or str
+    bool | str
         Returns True if the path exists, otherwise returns an error string
     """
     path = var.getValue()
@@ -176,7 +176,7 @@ def isfile(var):
 
     Returns
     -------
-    bool or str
+    bool | str
         Returns True if the path exists, otherwise returns an error string
     """
     path = var.getValue()
@@ -227,7 +227,7 @@ def between(var, a, b, inclusive=False):
         The upper bound comparison
     b: any
         The lower bound comparison
-    inclusive: bool or str, defaults=False
+    inclusive: bool | str, defaults=False
         Boundary inclusivity:
         - False   = Both bounds are exclusive
         - 'lower' = The lower bound is inclusive, upper is not
@@ -237,7 +237,7 @@ def between(var, a, b, inclusive=False):
 
     Returns
     -------
-    list or True
+    list | True
         Returns compare(value) with the correct bounds. If `value` is
         within specified bounds, return True, else return a list of strings
         which are the error message(s).
@@ -260,6 +260,20 @@ def between(var, a, b, inclusive=False):
 def one_valid(items):
     """
     Checks that one of the keys passes .validate()
+
+    Parameters
+    ----------
+    items: list of Var
+        Var objects to validate on
+
+    Returns
+    -------
+    True | str
+        Returns True if one item is valid, otherwise returns an error string
+
+    Notes
+    -----
+    This is a Sect check function, not be used for Vars
     """
     ov = False # One Valid
     for item in items:
@@ -284,6 +298,20 @@ def one_valid(items):
 def mutually_exclusive(items):
     """
     Checks that only one key is defined
+
+    Parameters
+    ----------
+    items: list of Var
+        Var objects to validate on
+
+    Returns
+    -------
+    True | str
+        Returns True if one item is valid, otherwise returns an error string
+
+    Notes
+    -----
+    This is a Sect check function, not be used for Vars
     """
     defined = []
     for item in items:
@@ -315,7 +343,7 @@ def check_dtype(value, dtype):
 
     Returns
     -------
-    True or str or list of str
+    True | str | list of str
         Returns True if this value is the expected type. If it is not, returns
         either a string or list of strings describing the error.
     """
@@ -323,8 +351,8 @@ def check_dtype(value, dtype):
         return True
 
     if isinstance(dtype, list):
-        if True not in [check_type(value, t) for t in dtype]:
-            return f'Value type <{dtype!r}> is not one of {dtype}'
+        if True not in [check_dtype(value, t) for t in dtype]:
+            return f'Value {value!r} (type: {type(value)}) is not one of types {dtype}'
         return True
 
     # Use a custom function to check the type

--- a/mlky/configs/config.py
+++ b/mlky/configs/config.py
@@ -22,12 +22,11 @@ Logger = logging.getLogger(__file__)
 
 
 class Config(Sect):
-    def __init__(self, data={}, patch=[], defs={}, debug=-1, validate=True, _raise=True, **kwargs):
+    def __init__(self, data={}, patch=[], defs={}, debug=-1, validate=True, **kwargs):
         """
         """
         # Config-specific private variables
         self.__dict__['_patch'] = patch = self.parsePatch(patch)
-        self.__dict__['_raise'] = _raise
 
         # If patching, don't apply defs with creation
         if patch:

--- a/mlky/configs/magics.py
+++ b/mlky/configs/magics.py
@@ -134,7 +134,8 @@ def replace(value, instance=None, dtype=None, callResets=False, _debug=_debug):
             else:
                 _debug(0, 'replace', f'Replacement matched to string but no valid starter token provided: {match!r}')
 
-            value = value.replace('${'+ match +'}', str(data))
+            if data is not Null:
+                value = value.replace('${'+ match +'}', str(data))
 
     if dtype:
         if isinstance(dtype, list):

--- a/mlky/configs/null.py
+++ b/mlky/configs/null.py
@@ -97,7 +97,7 @@ class NullType(type):
     def __repr__(cls):
         return 'Null'
 
-    def get(self, key, other=None):
+    def get(self, key, other=None, **kwargs):
         return other
 
     def keys(self):

--- a/mlky/configs/tests/test_funcs.py
+++ b/mlky/configs/tests/test_funcs.py
@@ -1,0 +1,57 @@
+"""
+Tests mlky builtin functions
+"""
+import pytest
+
+from mlky import (
+    funcs,
+    Null
+)
+
+
+@pytest.mark.parametrize("value,dtype,valid", [
+    # Single types, must be exact
+    ('1', str, True),
+    (1, int, True),
+    (1., float, True),
+    ([1], list, True),
+    ({1}, set, True),
+    ({1: 0}, dict, True),
+    # Multi-type checks, must be one of
+    ('1', [int, str], True),
+    (1, [int, str], True),
+    (1, [int, float], True),
+    (1., [int, float], True),
+    ('1', [int, float, str], True),
+    (1, [int, float, str], True),
+    (1., [int, float, str], True),
+    # Any type checks, value shouldn't matter
+    (1,  'any', True), ('1',  'any', True), (1.,  'any', True), ([1],  'any', True), ({1},  'any', True),
+    (1,   None, True), ('1',   None, True), (1.,   None, True), ([1],   None, True), ({1},   None, True),
+    (1,   Null, True), ('1',   Null, True), (1.,   Null, True), ([1],   Null, True), ({1},   Null, True),
+    (1, 'None', True), ('1', 'None', True), (1., 'None', True), ([1], 'None', True), ({1}, 'None', True),
+    (1, 'Null', True), ('1', 'Null', True), (1., 'Null', True), ([1], 'Null', True), ({1}, 'Null', True),
+    # Bad single type checks
+    (1, str, False),
+    ('1', int, False),
+    (1, float, False),
+    (1, list, False),
+    (1, set, False),
+    (1, dict, False),
+    # Bad multi-type checks
+    (1., [int, str], False),
+    ({1}, [int, str], False),
+    ('1', [int, float], False),
+    ({1}, [int, float], False),
+    ({1}, [int, float, str], False),
+    ([1], [int, float, str], False),
+])
+def test_dtypes(value, dtype, valid):
+    got = funcs.getRegister('check_dtype')(value, dtype)
+    if valid:
+        assert got is True, f'Expected True check for {value=}, {dtype=}, got: {got}'
+    else:
+        if isinstance(dtype, list):
+            assert "is not one of" in got, f"Expected 'is not one of' error for {value=}, {dtype=}, got: {got}"
+        else:
+            assert "Wrong type" in got, f"Expected 'Wrong type' error for {value=}, {dtype=}, got: {got}"

--- a/mlky/configs/tests/test_null.py
+++ b/mlky/configs/tests/test_null.py
@@ -1,6 +1,8 @@
 """
 Tests the mlky Null class
 """
+from time import sleep
+
 from mlky import (
     Null,
     NullDict
@@ -35,6 +37,9 @@ def test_warnings(caplog):
     """
     Verifies warnings can be disabled
     """
+    # Make sure a second has passed so the NullErrors works correctly
+    sleep(1)
+
     # Make sure the previously captured log messages are cleared out
     caplog.clear()
 
@@ -69,3 +74,11 @@ def test_NullDict():
     assert n.b    == 2
     assert n['b'] == 2
     assert n.a    == Null
+
+
+def test_iter():
+    """
+    """
+    # Make sure __iter__ doesn't work
+    for i in Null:
+        assert False, '__iter__ should not have been entered'

--- a/mlky/configs/var.py
+++ b/mlky/configs/var.py
@@ -56,6 +56,9 @@ class Var:
     # Will only call replace on magic strings, not any value
     _replace_only_if_magic = True
 
+    # Recursively call replace so values get populated correctly no matter order of operation
+    _replace_recursively = True
+
     # Replace backslashes "\" with Null
     _replace_slash_null = True
 
@@ -187,10 +190,10 @@ class Var:
             if errs:
                 Logger.error(f'Changing the value of this Var({self.name}) to will cause validation to fail. See var.validate() for errors')
 
-
         elif key == 'dtype':
             value = getType(value)
 
+        # Cast subtype dtypes to real types
         elif key == 'subtypes':
             for sub in value:
                 if 'dtype' not in sub:
@@ -437,7 +440,7 @@ class Var:
         # TODO: This is broken, just default to the global instance until further research
         parent = None
 
-        replacement = funcs.getRegister('config.replace')(value, parent, dtype=self.dtype)
+        replacement = funcs.getRegister('config.replace')(value, parent, dtype=self.dtype, callResets=self._replace_recursively, _debug=self._debug)
         if replacement is not value:
             self._debug(0, 'replace', f'Replacing {value!r} with {replacement!r}')
             return replacement

--- a/mlky/utils/formatters.py
+++ b/mlky/utils/formatters.py
@@ -46,12 +46,12 @@ def printTable(iterable, enum=False, delimiter='=', offset=1, prepend='', trunca
     left  = []
     right = []
     for item in iterable:
+        left.append(str(item[0]))
         if len(item) > 1:
-            left.append(str(item[0]))
             right.append(str(item[1]))
 
-    if not left:
-        return []
+    if not right:
+        return left
     elif isinstance(truncate, int):
         left = [item[:truncate] for item in left]
 

--- a/mlky/utils/formatters.py
+++ b/mlky/utils/formatters.py
@@ -47,11 +47,14 @@ def printTable(iterable, enum=False, delimiter='=', offset=1, prepend='', trunca
     right = []
     for item in iterable:
         left.append(str(item[0]))
+
         if len(item) > 1:
             right.append(str(item[1]))
+        else:
+            right.append(None)
 
-    if not right:
-        return left
+    if not left:
+        return []
     elif isinstance(truncate, int):
         left = [item[:truncate] for item in left]
 
@@ -61,16 +64,15 @@ def printTable(iterable, enum=False, delimiter='=', offset=1, prepend='', trunca
         formatter += '{i:' + f'{len(str(len(iterable)))}' + '}: '
     formatter += '{left:'+ str(padding) + '}' + delimiter + ' {right}'
 
-    i = 0
     formatted = []
-    for item in iterable:
+    for i, item in enumerate(iterable):
         if len(item) > 1:
             string = formatter.format(i=i, left=left[i], right=right[i])
             if len(item) > 2:
                 formatted.append((string, *item[2:]))
             else:
                 formatted.append((string, ))
-            i += 1
+
         else:
             formatted.append(item)
 

--- a/mlky/utils/track.py
+++ b/mlky/utils/track.py
@@ -1,0 +1,99 @@
+"""
+Tracks and reports the percentage complete for some arbitrary sized iterable
+
+Usage
+-----
+>>> from mlky.utils.track import Track
+>>> data = [0] * 77
+>>> report = Track(data)
+>>> for i in range(len(data)+1):
+...   report(i)
+  5.00% complete (elapsed: 0:00:00.000028, rate: 0:00:00, eta: 0:00:00.000532)
+ 10.00% complete (elapsed: 0:00:00.000099, rate: 0:00:00.000001, eta: 0:00:00.000891)
+ 15.00% complete (elapsed: 0:00:00.000106, rate: 0:00:00.000001, eta: 0:00:00.000601)
+ 20.00% complete (elapsed: 0:00:00.000112, rate: 0:00:00.000001, eta: 0:00:00.000448)
+ 25.00% complete (elapsed: 0:00:00.000117, rate: 0:00:00.000001, eta: 0:00:00.000351)
+ 30.00% complete (elapsed: 0:00:00.000122, rate: 0:00:00.000001, eta: 0:00:00.000285)
+ 35.00% complete (elapsed: 0:00:00.000127, rate: 0:00:00.000001, eta: 0:00:00.000236)
+ 40.00% complete (elapsed: 0:00:00.000132, rate: 0:00:00.000001, eta: 0:00:00.000198)
+ 45.00% complete (elapsed: 0:00:00.000136, rate: 0:00:00.000001, eta: 0:00:00.000166)
+ 50.00% complete (elapsed: 0:00:00.000141, rate: 0:00:00.000001, eta: 0:00:00.000141)
+ 55.00% complete (elapsed: 0:00:00.000146, rate: 0:00:00.000001, eta: 0:00:00.000119)
+ 60.00% complete (elapsed: 0:00:00.000151, rate: 0:00:00.000002, eta: 0:00:00.000101)
+ 65.00% complete (elapsed: 0:00:00.000156, rate: 0:00:00.000002, eta: 0:00:00.000084)
+ 70.00% complete (elapsed: 0:00:00.000160, rate: 0:00:00.000002, eta: 0:00:00.000069)
+ 75.00% complete (elapsed: 0:00:00.000165, rate: 0:00:00.000002, eta: 0:00:00.000055)
+ 80.00% complete (elapsed: 0:00:00.000170, rate: 0:00:00.000002, eta: 0:00:00.000042)
+ 85.00% complete (elapsed: 0:00:00.000175, rate: 0:00:00.000002, eta: 0:00:00.000031)
+ 90.00% complete (elapsed: 0:00:00.000179, rate: 0:00:00.000002, eta: 0:00:00.000020)
+ 95.00% complete (elapsed: 0:00:00.000184, rate: 0:00:00.000002, eta: 0:00:00.000010)
+100.00% complete (elapsed: 0:00:00.000189, rate: 0:00:00.000002, eta: 0:00:00)
+"""
+from datetime import datetime as dtt
+
+
+class Track:
+    """
+    Tracks and reports the percentage complete for some arbitrary sized iterable
+    """
+    def __init__(self, total, step=5, print=print, reverse=False, message="complete"):
+        """
+        Parameters
+        ----------
+        total: int, iterable
+            Total items in iterable. If iterable, will call len() on it
+        step: float, default=5
+            Step size to use for reporting
+        absolute: int, default=None
+            Changes the return
+        print: func, default=print
+            Print function to use, eg. logging.info
+        reverse: bool, default=False
+            Reverse the count such that 0 is 100%
+        message: str, default="complete"
+            Message to be included in the output
+        """
+        if hasattr(total, '__len__'):
+            total = len(total)
+
+        if step > 100:
+            raise AttributeError('Step size should be an integer representing a percentage, eg. 5 = report every 5%')
+
+        self.step = step
+        self.total = total
+        self.print = print
+        self.start = dtt.now()
+        self.percent = step
+        self.reverse = reverse
+        self.message = message
+
+    def __call__(self, count):
+        """
+        Parameters
+        ----------
+        count: int, iterable
+            The current count of items finished. If iterable, will call len() on it
+
+        Returns
+        -------
+        bool
+            True if a percentage step was just crossed, False otherwise
+        """
+        if hasattr(count, '__iter__'):
+            count = len(count)
+
+        current = count / self.total
+        if self.reverse:
+            current = 1 - current
+        current *= 100
+
+        if current >= self.percent:
+            elap = dtt.now() - self.start
+            rate = elap / self.total
+            esti = 100 / self.percent * elap - elap
+
+            self.print(f"{current:6.2f}% {self.message} (elapsed: {elap}, rate: {rate}, eta: {esti})")
+            self.percent += self.step
+
+            return True
+        return False


### PR DESCRIPTION
# Changes

- Adds subtype support to Var objects via the defs file
  - Enables setting different defs for different types on the same key 
- Adds subtype support to list types
  - Subtypes will only apply to an item in the list if a specific key's value matches the subtype
- Fixed endless loop `for i in Null`
  - Added test case to catch this
  - Created a `NullErrors` function that tracks how many errors are occurring within a time frame and will raise an 
exception if too many trigger (1k in 1 second)
- Added new options to `dumpYaml`
  - `comments=['inline', 'above', None]` to control how the comments are included
  - `nulls=bool` to exclude keys with Null values
  - `space=bool` to add a `\n` before every line in the output string