### PR TITLE
4.1.2

### DIFF
--- a/mlky/__init__.py
+++ b/mlky/__init__.py
@@ -1,6 +1,6 @@
 """
 """
-__version__ = '4.1.1'
+__version__ = '4.1.2'
 
 # Instantiate before the CLI
 from mlky.configs import *

--- a/mlky/__init__.py
+++ b/mlky/__init__.py
@@ -1,6 +1,6 @@
 """
 """
-__version__ = '4.1.0'
+__version__ = '4.1.1'
 
 # Instantiate before the CLI
 from mlky.configs import *

--- a/mlky/cli/__init__.py
+++ b/mlky/cli/__init__.py
@@ -1,3 +1,83 @@
+"""
+mlky comes with a [click](https://click.palletsprojects.com/en) CLI that is designed to
+easily integrate with other click CLIs. The following commands are provided
+out-of-the-box and immediately available once mlky is installed:
+
+```bash
+mlky generate
+mlky validate
+mlky print
+```
+
+Add `--help` to each of the above commands to view usage instructions.
+
+## Subcommands
+
+These commands can be added as subcommands to other click CLIs to abstract away the
+mlky command and/or to set defaults for the commands. For example:
+
+```python
+# This is your project's CLI (for example)
+@click.group(name='mypkg')
+def cli():
+    ...
+
+# Import mlky, set some defaults, and add the mlky commands to your cli
+import mlky
+
+defs = '/some/defs.yml'
+mlky.cli.setDefaults(defs=defs)
+
+cli.add_command(mlky.cli.commands)
+```
+
+This will nest the mlky subcommands under your project's CLI. Assuming your project
+was named `mypkg`, these commands are now accessible via:
+
+```bash
+mypkg generate ...
+mypkg validate ...
+mypkg print ...
+```
+
+## Common click options
+
+Several click options that are commonly used may be imported and either used as-is or
+modified for specific use-cases. The following click options are available:
+
+Option    | Flags                | Description                                 | Default Parameters
+------    | -----                | -----------                                 | ------------------
+config    | `-c`, `--config`     | Path to a mlky configuration file           | `required=True`
+patch     | `-p`, `--patch`      | Patch order for mlky                        |
+defs      | `--defs`             | Path to a mlky definitions file             |
+override  | `-o`, `--override`   | Override config keys                        | `multiple=True`
+liststyle | `-ls`, `--liststyle` | Sets the list style for the toYaml function | `type=click.Choice(['short', 'long']), default='short'`
+debug     | `--debug`            | Sets the mlky debug flag                    | `type=int`
+nointerp  | `-ni`, `--nointerp`  | Disables interpolation                      | `is_flag=True`
+
+These can be used to create custom functions, for example a config initializer:
+
+```python
+@mlky.cli.config
+@mlky.cli.patch
+@mlky.cli.defs(default="/path/to/some/defs.yml")
+@mlky.cli.override
+def initConfig(config, patch, defs, override):
+    C(config, _patch=patch, _defs=defs, _override=override)
+```
+
+Notice that the `defs` command is given a `default` parameter. Any additional
+parameters provided will override the default set by mlky.
+
+Another example, to disable the `required` flag of `--config`:
+
+```python
+@mlky.cli.config(required=False)
+def initConfig(config):
+    ...
+```
+
+"""
 from .cli import (
     commands,
     config,

--- a/mlky/cli/cli.py
+++ b/mlky/cli/cli.py
@@ -64,29 +64,39 @@ def createOption(flags, opts):
     return clickOption
 
 # Shared click options
-config    = createOption(['-c', '--config'], {
+config = createOption(['-c', '--config'], {
     'required': True,
     'help': 'Path to a mlky configuration file'
 })
-patch     = createOption(['-p', '--patch'], {
+
+patch = createOption(['-p', '--patch'], {
     'help': 'Patch order for mlky'
 })
-defs      = createOption(['--defs'], {
+
+defs = createOption(['--defs'], {
     'help': 'Path to a mlky definitions file'
 })
-override  = createOption(['-o', '--override'], {
+
+override = createOption(['-o', '--override'], {
     'type': (str, str),
     'multiple': True,
     'help': 'Override config keys'
 })
+
 liststyle = createOption(['-ls', '--liststyle'], {
     'type': click.Choice(['short', 'long']),
     'default': 'short',
     'help': 'Sets the list style for the toYaml function'
 })
+
 debug = createOption(['--debug'], {
     'type': int,
     'help': 'Sets the mlky debug flag'
+})
+
+nointerp = createOption(['-ni', '--noInterp'], {
+    'is_flag': True,
+    'help': 'Disables interpolation'
 })
 
 
@@ -116,13 +126,14 @@ def commands(ctx, version, path):
 @defs
 @override
 @liststyle
-def generate(file, defs, override, liststyle):
+@nointerp
+def generate(file, defs, override, liststyle, nointerp):
     """\
     Generates a default config template using the definitions file
     """
     Config(_defs=defs, _override=override)
 
-    Config.toYaml(file=file, listStyle=liststyle)
+    Config.toYaml(file=file, listStyle=liststyle, interp=not nointerp)
 
     click.echo(f"Wrote template configuration to: {file}")
 

--- a/mlky/cli/cli.py
+++ b/mlky/cli/cli.py
@@ -96,16 +96,16 @@ debug = createOption(['--debug'], {
 @click.option("-p", "--path", help="Print the installation path of MLky", is_flag=True)
 def commands(ctx, version, path):
     """\
-    MLky configuration commands
+    mlky configuration commands
     """
     import mlky
 
     if ctx.invoked_subcommand is None:
         if version:
-            click.echo(mlky.__version__)
+            click.echo(f'mlky-v{mlky.__version__}')
 
         if path:
-            click.echo(mlky.__path__[0])
+            click.echo(f'mlky installation: {mlky.__path__[0]}')
 
 
 @commands.command(name="generate")

--- a/mlky/cli/cli.py
+++ b/mlky/cli/cli.py
@@ -1,36 +1,3 @@
-"""
-The main CLI for mlky. Presently support the following commands:
-
-```bash
-mlky generate -f /some/config.yml -d /some/defs.yml [-s]
-mlky validate -f /some/config.yml [-i] -d /some/defs.yml [-di]
-```
-
-This CLI can be nested under other Click CLIs via:
-
-```python
-# This is your project's CLI (for example)
-@click.group(name='mypkg')
-def cli():
-    ...
-
-# Import mlky, set some defaults, and add the mlky commands to your cli
-import mlky
-
-defs = '/some/defs.yml'
-mlky.cli.setDefaults(defs=defs)
-
-cli.add_command(mlky.cli.commands)
-```
-
-This will nest the mlky subcommands under your project's. Assuming your project
-was named `mypkg`:
-
-```bash
-mypkg generate -f /some/config.yml -d /some/defs.yml
-mypkg validate -c /some/config.yml -d /some/defs.yml
-```
-"""
 import click
 
 from ..configs import Config
@@ -94,7 +61,7 @@ debug = createOption(['--debug'], {
     'help': 'Sets the mlky debug flag'
 })
 
-nointerp = createOption(['-ni', '--noInterp'], {
+nointerp = createOption(['-ni', '--nointerp'], {
     'is_flag': True,
     'help': 'Disables interpolation'
 })
@@ -129,13 +96,16 @@ def commands(ctx, version, path):
 @nointerp
 def generate(file, defs, override, liststyle, nointerp):
     """\
-    Generates a default config template using the definitions file
+    Generates a default config template using a definitions file
     """
-    Config(_defs=defs, _override=override)
+    if defs is None:
+        click.echo('No defs has been provided, a config cannot be generated')
+    else:
+        Config(_defs=defs, _override=override)
 
-    Config.toYaml(file=file, listStyle=liststyle, interp=not nointerp)
+        Config.toYaml(file=file, listStyle=liststyle, interp=not nointerp)
 
-    click.echo(f"Wrote template configuration to: {file}")
+        click.echo(f"Wrote template configuration to: {file}")
 
 
 @commands.command(name="validate")
@@ -148,16 +118,19 @@ def validate(config, patch, defs, override, debug):
     """\
     Validates a configuration file against a definitions file
     """
-    click.echo(f'Validation results for {config}:')
+    if defs is None:
+        click.echo('No defs has been provided, the config cannot be validated')
+    else:
+        click.echo(f'Validation results for {config}:')
 
-    if debug:
-        Config.enableLogging()
+        if debug:
+            Config.enableLogging()
 
-    Config(config, _patch=patch, _defs=defs, _override=override, _debug=debug)
+        Config(config, _patch=patch, _defs=defs, _override=override, _debug=debug)
 
-    valid = Config.validateObj()
-    if valid:
-        click.echo(f'No errors were found.')
+        valid = Config.validateObj()
+        if valid:
+            click.echo(f'No errors were found.')
 
 
 @commands.command(name="print")

--- a/mlky/configs/base.py
+++ b/mlky/configs/base.py
@@ -784,6 +784,10 @@ class BaseSect:
                     Short will condense the items to a single line between [] brackets.
                     Short only works if all items of the list are Var types (not lists
                     or dicts)
+            Var:
+                interp : bool, default=True
+                    Allow interpolation of values. Setting to False will allow
+                    interpolation strings to be printed
         """
         # Determine if to convert this obj to YAML depending on the tags
         if tags:

--- a/mlky/configs/base.py
+++ b/mlky/configs/base.py
@@ -803,12 +803,14 @@ class BaseSect:
 
         # Convert self to YAML
         offset = 2
+        desc   = ''
         if isSectType(self._parent, 'list'):
             line = '- '
         elif isSectType(self._parent, 'dict'):
             line = f'{self._key}:'
         elif header:
             line = 'generated:'
+            desc = 'Generated via mlky toYaml'
         else:
             line = ''
             offset = 0
@@ -819,7 +821,7 @@ class BaseSect:
 
         flag  = '*' if defs.get('required') else ' '
         dtype = self._dtype
-        sdesc = defs.get('sdesc', '')
+        sdesc = defs.get('sdesc', desc)
         if line:
             line = [line, flag, dtype, sdesc]
 

--- a/mlky/configs/base.py
+++ b/mlky/configs/base.py
@@ -49,8 +49,11 @@ class BaseSect:
     _dtype    = ''    # Data type for this object
     _override = None  # CLI override data
 
+    # DictSect flags
+    _patch = None
+
     # ListSect flags
-    _patchAppend    = False
+    _patchAppend = False
 
     # Var flags
     _coerce         = True

--- a/mlky/configs/null.py
+++ b/mlky/configs/null.py
@@ -25,7 +25,7 @@ def NullErrors(msg, warn):
     else:
         NullErrors.err = 0
 
-    if warn and elapse < .1:
+    if warn and elapse > .1:
         Logger.warning(msg)
 
     NullErrors.now = now
@@ -112,7 +112,10 @@ class NullType(type):
     _warn = True
 
     def __call__(cls, *args, **kwargs):
-        context = getContext()
+        try:
+            context = getContext()
+        except:
+            context = ''
 
         NullErrors(f'Null received a call like a function, was this intended? {context}', cls._warn)
 

--- a/mlky/configs/types.py
+++ b/mlky/configs/types.py
@@ -88,9 +88,6 @@ class Bool(metaclass=Types):
 
     @classmethod
     def cast(cls, value):
-        if value is Null:
-            return '\\'
-
         if isinstance(value, str):
             if value.lower() == 'false':
                 value = False
@@ -115,8 +112,8 @@ class Path(metaclass=Types):
     @classmethod
     def cast(cls, value):
         if value is Null:
-            return '\\'
-
+            return value
+        
         return cls.dtype(str(value))
 
 


### PR DESCRIPTION
Expands the CLI capabilities slightly and improves the traceback debugging of Null objects that are called like a function:

```python
>>> from mlky import Config as C
>>> C(a={'b': 1})
>>> # Reports where and what causes a Null call to occur
>>> C.a.z()
Null received a call like a function, was this intended? Context:
  File "/var/folders/ct/j3f5qjrd209cw3dl3c7hg1nm0000gq/T/ipykernel_47862/2923035938.py", line 1, in <module>
    C.a.z()
    Identified as Null: C.a.z
Null
>>> # If multiple null calls occur on the same line, reports all of them
>>> C.a.z(), C.b()
Null received a call like a function, was this intended? Context:
  File "/var/folders/ct/j3f5qjrd209cw3dl3c7hg1nm0000gq/T/ipykernel_47862/2143101163.py", line 1, in <module>
    C.a.z(), C.b()
    Identified as Null: 
    - C.a.z
    - C.b
(Null, Null)
>>> # Detects which part of a null path is actually null
>>> C.a.z(), C.b.abc()
Null received a call like a function, was this intended? Context:
  File "/var/folders/ct/j3f5qjrd209cw3dl3c7hg1nm0000gq/T/ipykernel_47862/2143101163.py", line 1, in <module>
    C.a.z(), C.b()
    Identified as Null: 
    - C.a.z
    - C.b
(Null, Null)
```

The above was done in a jupyter notebook as this doesn't seem to work in an interpreter. Considering the interpreter to be low priority.